### PR TITLE
box-shadow in Gmail — no support at all

### DIFF
--- a/docs/_data/features.yaml
+++ b/docs/_data/features.yaml
@@ -181,7 +181,7 @@
       href: https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow
       clients:
         - client: "1"
-          compatible: "yes"
+          compatible: "no"
         - client: "2"
           compatible: "yes"
         - client: "3"


### PR DESCRIPTION
## Description
Both web and Android versions of Gmail do completely strip box-shadow rules from inline styles and from <style> tags. I can provide test HTML email code or send you one to a provided email address.

Only box-shadow gets stripped. For example, .some-class{ background-color:#d00; box-shadow: 10px 5px 5px red; } becomes .msg123123some-class{ background-color:#d00; } 

Guess that Gmail does not want box-shadow to be able to cover Gmail itself, and are lazy to parse and limit actual box-shadow values, accounting for all CSS units.


## Motivation and Context
Currently, the caniuse.email website lists box-shadow as supported by Gmail web version, which is wrong judging by my tests.

## How Has This Been Tested?
Several HTML letters send to myself from a PHP script — viewed in Gmail web, Gmail Android, Thunderbird on Windows — all fresh.

## Screenshots (if appropriate):
http://matvey.kiev.ua/tmp/github/box-shadow-gmail-web-nov2019.png (will be deleted after a few months).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
